### PR TITLE
bnxt_re/lib: Resize CQ support

### DIFF
--- a/providers/bnxt_re/bnxt_re-abi.h
+++ b/providers/bnxt_re/bnxt_re-abi.h
@@ -49,6 +49,8 @@ DECLARE_DRV_CMD(ubnxt_re_pd, IB_USER_VERBS_CMD_ALLOC_PD,
 		empty, bnxt_re_pd_resp);
 DECLARE_DRV_CMD(ubnxt_re_cq, IB_USER_VERBS_CMD_CREATE_CQ,
 		bnxt_re_cq_req, bnxt_re_cq_resp);
+DECLARE_DRV_CMD(ubnxt_re_resize_cq, IB_USER_VERBS_CMD_RESIZE_CQ,
+		bnxt_re_resize_cq_req, empty);
 DECLARE_DRV_CMD(ubnxt_re_qp, IB_USER_VERBS_CMD_CREATE_QP,
 		bnxt_re_qp_req, bnxt_re_qp_resp);
 DECLARE_DRV_CMD(ubnxt_re_cntx, IB_USER_VERBS_CMD_GET_CONTEXT,

--- a/providers/bnxt_re/main.c
+++ b/providers/bnxt_re/main.c
@@ -100,6 +100,7 @@ static const struct verbs_context_ops bnxt_re_cntx_ops = {
 	.create_cq     = bnxt_re_create_cq,
 	.poll_cq       = bnxt_re_poll_cq,
 	.req_notify_cq = bnxt_re_arm_cq,
+	.resize_cq     = bnxt_re_resize_cq,
 	.destroy_cq    = bnxt_re_destroy_cq,
 	.create_srq    = bnxt_re_create_srq,
 	.modify_srq    = bnxt_re_modify_srq,

--- a/providers/bnxt_re/main.h
+++ b/providers/bnxt_re/main.h
@@ -80,9 +80,11 @@ struct bnxt_re_cq {
 	struct ibv_cq ibvcq;
 	uint32_t cqid;
 	struct bnxt_re_queue cqq;
+	struct bnxt_re_queue resize_cqq;
 	struct bnxt_re_dpi *udpi;
 	struct list_head sfhead;
 	struct list_head rfhead;
+	struct list_head prev_cq_head;
 	uint32_t cqe_size;
 	uint8_t  phase;
 	int deferred_arm_flags;

--- a/providers/bnxt_re/verbs.c
+++ b/providers/bnxt_re/verbs.c
@@ -53,6 +53,8 @@
 #include "main.h"
 #include "verbs.h"
 
+static int bnxt_re_poll_one(struct bnxt_re_cq *cq, int nwc, struct ibv_wc *wc,
+			    uint32_t *resize);
 int bnxt_re_query_device(struct ibv_context *context,
 			 const struct ibv_query_device_ex_input *input,
 			 struct ibv_device_attr_ex *attr, size_t attr_size)
@@ -213,6 +215,7 @@ struct ibv_cq *bnxt_re_create_cq(struct ibv_context *ibvctx, int ncqe,
 
 	list_head_init(&cq->sfhead);
 	list_head_init(&cq->rfhead);
+	list_head_init(&cq->prev_cq_head);
 
 	return &cq->ibvcq;
 cmdfail:
@@ -220,6 +223,103 @@ cmdfail:
 fail:
 	free(cq);
 	return NULL;
+}
+
+static int bnxt_re_poll_kernel_cq(struct bnxt_re_cq *cq)
+{
+	struct ibv_wc tmp_wc;
+	int rc;
+
+	rc = ibv_cmd_poll_cq(&cq->ibvcq, 1, &tmp_wc);
+	if (rc)
+		fprintf(stderr, "ibv_cmd_poll_cq failed: %d\n", rc);
+	return rc;
+}
+
+/*
+ * Function to complete the last steps in CQ resize. Invoke poll function
+ * in the kernel driver; this serves as a signal to the driver to complete CQ
+ * resize steps required. Free memory mapped for the original CQ and switch
+ * over to the memory mapped for CQ with the new size. Finally Ack the Cutoff
+ * CQE. This function must be called under cq->cqq.lock.
+ */
+static void bnxt_re_resize_cq_complete(struct bnxt_re_cq *cq)
+{
+	bnxt_re_poll_kernel_cq(cq);
+	bnxt_re_free_aligned(&cq->cqq);
+	memcpy(&cq->cqq, &cq->resize_cqq, sizeof(cq->cqq));
+	bnxt_re_ring_cq_arm_db(cq, BNXT_RE_QUE_TYPE_CQ_CUT_ACK);
+}
+
+int bnxt_re_resize_cq(struct ibv_cq *ibvcq, int ncqe)
+{
+	struct bnxt_re_dev *dev = to_bnxt_re_dev(ibvcq->context->device);
+	struct bnxt_re_cq *cq = to_bnxt_re_cq(ibvcq);
+	struct ib_uverbs_resize_cq_resp resp = {};
+	struct ubnxt_re_resize_cq cmd = {};
+	int rc = 0;
+
+	if (ncqe > dev->max_cq_depth)
+		return -EINVAL;
+
+	pthread_spin_lock(&cq->cqq.qlock);
+	cq->resize_cqq.depth = roundup_pow_of_two(ncqe + 1);
+	if (cq->resize_cqq.depth > dev->max_cq_depth + 1)
+		cq->resize_cqq.depth = dev->max_cq_depth + 1;
+	cq->resize_cqq.stride = dev->cqe_size;
+	if (bnxt_re_alloc_aligned(&cq->resize_cqq, dev->pg_size))
+		goto done;
+	/* As an exception no need to call get_ring api we know
+	 * this is the only consumer
+	 */
+	cmd.cq_va = (uint64_t)cq->resize_cqq.va;
+	rc = ibv_cmd_resize_cq(ibvcq, ncqe, &cmd.ibv_cmd,
+			       sizeof(cmd), &resp, sizeof(resp));
+	if (rc) {
+		bnxt_re_free_aligned(&cq->resize_cqq);
+		goto done;
+	}
+
+	while (true) {
+		struct bnxt_re_work_compl *compl = NULL;
+		struct ibv_wc tmp_wc = {};
+		uint32_t resize = 0;
+		int dqed = 0;
+
+		dqed = bnxt_re_poll_one(cq, 1, &tmp_wc, &resize);
+		if (resize) {
+			if (cq->deferred_arm) {
+				bnxt_re_ring_cq_arm_db(cq, cq->deferred_arm_flags);
+				cq->deferred_arm = false;
+			}
+			break;
+		}
+		if (dqed) {
+			compl = calloc(1, sizeof(*compl));
+			if (!compl)
+				break;
+			memcpy(&compl->wc, &tmp_wc, sizeof(tmp_wc));
+			list_add_tail(&cq->prev_cq_head, &compl->list);
+			compl = NULL;
+			memset(&tmp_wc, 0, sizeof(tmp_wc));
+		}
+	}
+done:
+	pthread_spin_unlock(&cq->cqq.qlock);
+	return rc;
+}
+
+static void bnxt_re_destroy_resize_cq_list(struct bnxt_re_cq *cq)
+{
+	struct bnxt_re_work_compl *compl, *tmp;
+
+	if (list_empty(&cq->prev_cq_head))
+		return;
+
+	list_for_each_safe(&cq->prev_cq_head, compl, tmp, list) {
+		list_del(&compl->list);
+		free(compl);
+	}
 }
 
 int bnxt_re_destroy_cq(struct ibv_cq *ibvcq)
@@ -230,7 +330,7 @@ int bnxt_re_destroy_cq(struct ibv_cq *ibvcq)
 	status = ibv_cmd_destroy_cq(ibvcq);
 	if (status)
 		return status;
-
+	bnxt_re_destroy_resize_cq_list(cq);
 	bnxt_re_free_aligned(&cq->cqq);
 	free(cq);
 
@@ -511,7 +611,8 @@ static uint8_t bnxt_re_poll_term_cqe(struct bnxt_re_qp *qp,
 	return pcqe;
 }
 
-static int bnxt_re_poll_one(struct bnxt_re_cq *cq, int nwc, struct ibv_wc *wc)
+static int bnxt_re_poll_one(struct bnxt_re_cq *cq, int nwc, struct ibv_wc *wc,
+			    uint32_t *resize)
 {
 	struct bnxt_re_queue *cqq = &cq->cqq;
 	struct bnxt_re_qp *qp;
@@ -562,7 +663,11 @@ static int bnxt_re_poll_one(struct bnxt_re_cq *cq, int nwc, struct ibv_wc *wc)
 			pcqe = bnxt_re_poll_term_cqe(qp, wc, cqe, &cnt);
 			break;
 		case BNXT_RE_WC_TYPE_COFF:
-			break;
+			/* Stop further processing and return */
+			bnxt_re_resize_cq_complete(cq);
+			if (resize)
+				*resize = 1;
+			return dqed;
 		default:
 			break;
 		};
@@ -690,14 +795,45 @@ static int bnxt_re_poll_flush_lists(struct bnxt_re_cq *cq, uint32_t nwc,
 	return polled;
 }
 
+static int bnxt_re_poll_resize_cq_list(struct bnxt_re_cq *cq, uint32_t nwc,
+				       struct ibv_wc *ibvwc)
+{
+	struct bnxt_re_work_compl *compl, *tmp;
+	int left;
+
+	left = nwc;
+	list_for_each_safe(&cq->prev_cq_head, compl, tmp, list) {
+		if (!left)
+			break;
+		memcpy(ibvwc, &compl->wc, sizeof(*ibvwc));
+		ibvwc++;
+		left--;
+		list_del(&compl->list);
+		free(compl);
+	}
+
+	return nwc - left;
+}
+
 int bnxt_re_poll_cq(struct ibv_cq *ibvcq, int nwc, struct ibv_wc *wc)
 {
 	struct bnxt_re_cq *cq = to_bnxt_re_cq(ibvcq);
 	struct bnxt_re_context *cntx = to_bnxt_re_context(ibvcq->context);
-	int dqed, left = 0;
+	int dqed = 0, left = 0;
+	uint32_t resize = 0;
 
 	pthread_spin_lock(&cq->cqq.qlock);
-	dqed = bnxt_re_poll_one(cq, nwc, wc);
+	left = nwc;
+	/* Check  whether we have anything to be completed from prev cq context */
+	if (!list_empty(&cq->prev_cq_head)) {
+		dqed = bnxt_re_poll_resize_cq_list(cq, nwc, wc);
+		left = nwc - dqed;
+		if (!left) {
+			pthread_spin_unlock(&cq->cqq.qlock);
+			return dqed;
+		}
+	}
+	dqed += bnxt_re_poll_one(cq, left, wc + dqed, &resize);
 	if (cq->deferred_arm) {
 		bnxt_re_ring_cq_arm_db(cq, cq->deferred_arm_flags);
 		cq->deferred_arm = false;

--- a/providers/bnxt_re/verbs.h
+++ b/providers/bnxt_re/verbs.h
@@ -50,9 +50,15 @@
 #include <sys/mman.h>
 #include <netinet/in.h>
 #include <unistd.h>
+#include <ccan/list.h>
 
 #include <infiniband/driver.h>
 #include <infiniband/verbs.h>
+
+struct bnxt_re_work_compl {
+	struct list_node list;
+	struct ibv_wc wc;
+};
 
 int bnxt_re_query_device(struct ibv_context *context,
 			 const struct ibv_query_device_ex_input *input,
@@ -67,6 +73,7 @@ int bnxt_re_dereg_mr(struct verbs_mr *vmr);
 
 struct ibv_cq *bnxt_re_create_cq(struct ibv_context *uctx, int ncqe,
 				 struct ibv_comp_channel *ch, int vec);
+int bnxt_re_resize_cq(struct ibv_cq *ibvcq, int ncqe);
 int bnxt_re_destroy_cq(struct ibv_cq *ibvcq);
 int bnxt_re_poll_cq(struct ibv_cq *ibvcq, int nwc, struct ibv_wc *wc);
 int bnxt_re_arm_cq(struct ibv_cq *ibvcq, int flags);


### PR DESCRIPTION
Adds resize CQ support. After issuing the resize_cq cmd, lib
reaps all the existing completions in the CQ and store it in
a list. The reaping continues till the final CQE. Once final
CQE is seen, it issues a ibv_cmd_poll_cq so the poll_cq context
in the kernel is invoked and driver frees up the previous CQ
resources.

During a poll CQ from application, the pending completions in
the list is completed first before polling completions from the
new CQ.

Signed-off-by: Selvin Xavier <selvin.xavier@broadcom.com>